### PR TITLE
Add Snyder GFP ChIP subs 3605 & 3606.

### DIFF
--- a/snyder_conf/snyder_gfp_tf.conf
+++ b/snyder_conf/snyder_gfp_tf.conf
@@ -1,5 +1,6 @@
 # Snyder's tracks: Anti-GFP Ab
 
+
 [SNYDER_ANTIGFP_CHIPCHIP_ALY2:70001]
 glyph_subtype = density
 height        = 12
@@ -326,21 +327,20 @@ citation = <h1> Identification of AMA-1::GFP Binding Regions in L4 Young Adult (
  <b>Release Date:</b> 2009-11-27  Track 589
 
 
-[Snyder_ANTIGFP_WIG_COMB_BLMP1_GFP:70001]
+[Snyder_ANTIGFP_WIG_COMB_BLMP1_GFP_L1:70001]
 glyph_subtype = density
 height       = 12
 
 
-[Snyder_ANTIGFP_WIG_COMB_BLMP1_GFP]
-feature      = VISTA:5426
-	       VISTA:18273
+[Snyder_ANTIGFP_WIG_COMB_BLMP1_GFP_L1]
+feature      = VISTA:5426 
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 2612 2612 4036
-track source = 5426 5418 18273
+data source  = 2612 2612
+track source = 5426 5418
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -374,15 +374,11 @@ label        = sub {my $name = shift->name;
 label_position = left
 label density= 100
 smoothing_window = 16
-key          = BLMP-1 Combined (GFP ChIP)
-select       = name;
-	       L1 "L1" = 2612;
-	       Emb "Emb" = 4036;
+key          = BLMP-1 Combined (GFP ChIP) 
 group_on     =
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
-		     my %subs = (5426=>2612,
-				 18273=>4036);
+		     my %subs = (5426=>2612);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -1312,8 +1308,9 @@ height        = 12
 [SNYDER_ANTIGFP_CHIPCHIP_EFL1]
 feature      = VISTA:9107
                VISTA:9188
-data source  = 3072 3072 3074 3074
-track source = 9107 9114 9188 9201
+	       VISTA:18847
+data source  = 3072 3072 3074 3074 3605 3605
+track source = 9107 9114 9188 9201 18847 18868
 glyph        = vista_plot
 glyph select = vista_plot
 autoscale     = z_score
@@ -1335,6 +1332,7 @@ bump density = 250
 select       = name;
                PIE1_EFL1_GFP_YA  "PIE1_EFL1_GFP_YA" = 3072;
                Pefl1_EFL1_GFP_L1 "Pefl1_EFL1_GFP_L1" = 3074;
+	       N2_EFL1_anti-EFL1_L1 "N2_EFL1_anti-EFL1_L1" = 3605;
 category     = Transcription Factors: GFP ChIP
 sort_order   = name
 stranded     = 0
@@ -1359,7 +1357,8 @@ label        = sub {my $name = shift->name;
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
                      my %subs =(9107=>3072,
-                                9188=>3074);
+                                9188=>3074,
+				18847=>3605);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -1626,21 +1625,20 @@ citation = <h1>Identification of Transcription Factor EGL-27::GFP Binding Region
  <b>Release Date:</b> 2010-02-10  Track 2621
 
 
-[Snyder_ANTIGFP_WIG_COMB_ELT3_GFP:70001]
+[Snyder_ANTIGFP_WIG_COMB_ELT3_GFP_L1:70001]
 glyph_subtype = density
 height       = 12
 
 
-[Snyder_ANTIGFP_WIG_COMB_ELT3_GFP]
-feature      = VISTA:5415
-	       VISTA:17976 
+[Snyder_ANTIGFP_WIG_COMB_ELT3_GFP_L1]
+feature      = VISTA:5415 
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 2614 2614 4789
-track source = 5415 5408 17976
+data source  = 2614 2614
+track source = 5415 5408
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -1674,15 +1672,11 @@ label        = sub {my $name = shift->name;
 label_position = left
 label density= 100
 smoothing_window = 16
-key          = ELT-3 Combined i(GFP ChIP)
-select       = name;
-	       L1 "L1" = 2614;
-	       EMB "EMB" = 4789;
+key          = ELT-3 Combined (GFP ChIP) 
 group_on     =
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
-		     my %subs = (5415=>2614,
-				 17976=>4789);
+		     my %subs = (5415=>2614);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -2173,9 +2167,8 @@ height        = 12
 feature      = VISTA:4366
                VISTA:9256
 	       VISTA:11317
-	       VISTA:18316
-data source  = 2451 2451 3149 3149 3066 3066 4037
-track source = 4366 4360 9256 9269 11317 11322 18316
+data source  = 2451 2451 3149 3149 3066 3066
+track source = 4366 4360 9256 9269 11317 11322
 glyph        = vista_plot
 glyph select = vista_plot
 autoscale     = z_score
@@ -2198,7 +2191,6 @@ select       = name;
                GEI11_L4_GFP "GEI11_L4_GFP" = 2451;
                GEI11_L2_GFP "GEI11_L2_GFP" = 3149;
 	       GEI11_L3_GFP "GEI11_L3_GFP" = 3066;
-	       Emb "Emb" = 4037;
 category     = Transcription Factors: GFP ChIP
 sort_order   = name
 stranded     = 0
@@ -2224,8 +2216,7 @@ link         = sub { my $feature = shift;
 		     my $src = $feature->source;
                      my %subs =(4366=>2451,
                                 9256=>3149,
-				11317=>3066,
-				18316=>4037);
+				11317=>3066);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -2505,23 +2496,20 @@ citation = <h1>Identification of Transcription Factor LIN-11::GFP Binding Region
 
 
 
-[Snyder_ANTIGFP_WIG_COMB_LIN13_GFP:70001]
+[Snyder_ANTIGFP_WIG_COMB_LIN13_GFP_emb:70001]
 glyph_subtype = density
 height       = 12
 
 
-[Snyder_ANTIGFP_WIG_COMB_LIN13_GFP]
-feature      = VISTA:5425
-	       VISTA:17881
-	       VISTA:17900
-	       VISTA:17937
+[Snyder_ANTIGFP_WIG_COMB_LIN13_GFP_emb]
+feature      = VISTA:5425 
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 2613 2613 4793 4794 4795
-track source = 5425 5417 17881 17900 17937
+data source  = 2613 2613
+track source = 5425 5417
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -2555,19 +2543,11 @@ label        = sub {my $name = shift->name;
 label_position = left
 label density= 100
 smoothing_window = 16
-key          = LIN-13 Combined (GFP ChIP)
-select       = name;
-	       EMB "EMB" = 2613;
-	       L1 "L1" = 4793;
-	       L2 "L2" = 4794;
-	       L3 "L3" = 4795;
+key          = LIN-13 Combined (GFP ChIP) 
 group_on     =
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
-		     my %subs = (5425=>2613,
-				 17881=>4793,
-				 17900=>4794,
-				 17937=>4795);
+		     my %subs = (5425=>2613);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -2747,22 +2727,20 @@ citation     = <h1>Identification of Transcription Factor LIN-15B::GFP Binding R
 
 
 
-[Snyder_ANTIGFP_WIG_COMB_LIN39_GFP:70001]
+[Snyder_ANTIGFP_WIG_COMB_LIN39_L3_GFP:70001]
 glyph_subtype = density
 height       = 12
 
-[Snyder_ANTIGFP_WIG_COMB_LIN39_GFP]
+
+[Snyder_ANTIGFP_WIG_COMB_LIN39_L3_GFP]
 feature      = VISTA:4324 
-	       VISTA:18210
-	       VISTA:18357
-	       VISTA:18283
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 2432 2432 4015 4016 4032
-track source = 4324 4320 18210 18357 18283
+data source  = 2432 2432
+track source = 4324 4320
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -2796,19 +2774,11 @@ label        = sub {my $name = shift->name;
 label_position = left
 label density= 100
 smoothing_window = 16
-key          = LIN-39 Combined (GFP ChIP)
-select       = name;
-	       L3 "L3" = 2432;
-	       L2 "L2" = 4015;
-	       L4 "L4" = 4016;
-	       L1 "L1" = 4032;
+key          = LIN-39 Combined (GFP ChIP) 
 group_on     =
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
-		     my %subs = (4324=>2432,
-				 18210=>4015,
-				 18357=>4016,
-				 18283=>4032);
+		     my %subs = (4324=>2432);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -2865,21 +2835,20 @@ citation = <h1> Identification of Transcription Factor LIN-39::GFP Binding Regio
 
 
 
-[Snyder_ANTIGFP_WIG_COMB_MAB5_GFP:70001]
+[Snyder_ANTIGFP_WIG_COMB_MAB5_L3_GFP:70001]
 glyph_subtype = density
 height       = 12
 
 
-[Snyder_ANTIGFP_WIG_COMB_MAB5_GFP]
-feature      = VISTA:4284
-	       VISTA:18652
+[Snyder_ANTIGFP_WIG_COMB_MAB5_L3_GFP]
+feature      = VISTA:4284 
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 593 593 3840
-track source = 4284 4279 18652
+data source  = 593 593
+track source = 4284 4279
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -2913,15 +2882,11 @@ label        = sub {my $name = shift->name;
 label_position = left
 label density= 100
 smoothing_window = 16
-key          = MAB-5 Combined (GFP ChIP)
-select       = name;
-	       MAB5_L3_GFP "MAB5_L3_GFP" = 593;
-	       MAB-5_Emb "MAB-5_Emb" = 3840;
+key          = MAB-5 Combined (GFP ChIP) 
 group_on     =
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
-	             my %subs = (4284=>593,
-				 18652=>3840);
+	             my %subs = (4284=>593);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -3413,12 +3378,8 @@ height        = 12
 
 [SNYDER_ANTIGFP_CHIPCHIP_NHR11]
 feature      = VISTA:9123
-	       VISTA:18248
-	       VISTA:18221
-	       VISTA:18267
-	       VISTA:18228
-data source  = 3079 3079 4013 4014 4022 4023
-track source = 9123 9139 18248 18221 18267 18228
+data source  = 3079 3079
+track source = 9123 9139
 glyph        = vista_plot
 glyph select = vista_plot
 autoscale     = z_score
@@ -3446,13 +3407,6 @@ label density= 100
 smoothing    = mean
 smoothing_window = 10
 key          = NHR-11 Combined (GFP ChIP)
-select       = name;
-	       L2 "L2" = 3079;
-	       L3 "L3" = 4013;
-	       L4 "L4" = 4014;
-	       LEMB "LEMB" = 4022;
-	       L1 "L1" = 4023;
-	       
 group_on     =
 bicolor_pivot= zero
 balloon hover = sub {my $f = shift;
@@ -3467,11 +3421,7 @@ label        = sub {my $name = shift->name;
                     return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
 link         = sub { my $feature = shift;
                      my $src = $feature->source;
-                     my %subs =(9123=>3079,
-				18248=>4013,
-				18221=>4014,
-				18267=>4022,
-				18228=>4023);
+                     my %subs =(9123=>3079);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -3533,10 +3483,8 @@ height        = 12
 [SNYDER_ANTIGFP_CHIPCHIP_NHR28]
 feature      = VISTA:8157
                VISTA:8266
-	       VISTA:18325
-	       VISTA:18348
-data source  = 3223 3223 3386 3386 4019 4024
-track source = 8157 8163 8266 8271 18325 18348
+data source  = 3223 3223 3386 3386
+track source = 8157 8163 8266 8271
 glyph        = vista_plot
 glyph select = vista_plot
 autoscale     = z_score
@@ -3558,8 +3506,6 @@ bump density = 250
 select       = name;
                NHR28_GFP_L4 "NHR-28_GFP_L4" = 3223;
                NHR28_GFP_L3 "NHR-28_GFP_L3" = 3386;
-	       EMB "EMB" = 4019;
-	       L1 "L1" = 4024;
 category     = Transcription Factors: GFP ChIP
 sort_order   = name
 stranded     = 0
@@ -3584,9 +3530,7 @@ label        = sub {my $name = shift->name;
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
                      my %subs =(8157=>3223,
-                                8266=>3386,
-				18325=>4019,
-				18348=>4024);
+                                8266=>3386);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -3857,9 +3801,13 @@ citation = <h1> Identification of Transcription Factor PES-1::GFP Binding Region
  <br />
  <b>Release Date:</b> 2009-11-28
 
+
+
+
 [Snyder_PHA4_GFP_COMB:70001]
 glyph_subtype = density
 height       = 12
+
 
 [Snyder_PHA4_GFP_COMB]
 feature      = VISTA:4239
@@ -3868,14 +3816,13 @@ feature      = VISTA:4239
                VISTA:7913
                VISTA:5406
                VISTA:8006
-	       VISTA:18732
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 582 582 584 584 585 585 3158 3158 2598 2598 3161 3161 2945
-track source = 4239 4241 4245 4240 4249 4235 7913 7920 5406 5401 8006 8012 18732
+data source  = 582 582 584 584 585 585 3158 3158 2598 2598 3161 3161
+track source = 4239 4241 4245 4240 4249 4235 7913 7920 5406 5401 8006 8012
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -3919,7 +3866,6 @@ select         = name;
 	         PHA4_StarvedL1_GFP "PHA4_StarvedL1_GFP" = 584;
 	         PHA4_GFP_YA "PHA4_GFP_YA" = 3161;
 	         PHA4_GFP_lemb "PHA4_GFP_lemb" = 2598;
-		 PHA-4_L4 "PHA-4_L4" = 2945;
 key          = PHA-4 Combined (GFP ChIP)
 group_on     =
 link         = sub { my $feature = shift;
@@ -3929,8 +3875,7 @@ link         = sub { my $feature = shift;
                                  4239=>585,
                                  7913=>3158,
                                  8006=>3161,
-                                 5406=>2598,
-				 18732=>2945);
+                                 5406=>2598);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -4106,16 +4051,15 @@ citation = <h1>Identification of Transcription Factor PQM-1::GFP Binding Regions
 
 
 
-[SNYDER_ANTIGFP_CHIPCHIP_R02D37:70001]
+[SNYDER_ANTIGFP_CHIPCHIP_R02D3:70001]
 glyph_subtype = density
 height        = 12
 
-[SNYDER_ANTIGFP_CHIPCHIP_R02D37]
+[SNYDER_ANTIGFP_CHIPCHIP_R02D3]
 feature      = VISTA:8255
 	       VISTA:14869
-	       VISTA:18721
-data source  = 3385 3385 3586 3586 3077
-track source = 8255 8263 14869 14876 18721
+data source  = 3385 3385 3586 3586
+track source = 8255 8263 14869 14876
 glyph        = vista_plot
 glyph select = vista_plot
 autoscale     = z_score
@@ -4137,7 +4081,6 @@ bump density = 250
 select	     = name;
 	       R02D3.7_GFP_L2 "R02D3.7_GFP_L2" = 3385;
                R02D3.7_GFP_L3 "R02D3.7_GFP_L3" = 3586;
-	       R02D3.7_L4 "R02D3.7_L4" = 3077;
 category     = Transcription Factors: GFP ChIP
 sort_order   = name
 stranded     = 0
@@ -4162,8 +4105,7 @@ label        = sub {my $name = shift->name;
 link         = sub { my $feature = shift;
                      my $src = $feature->source;
                      my %subs =(8255=>3385,
-				14869=>3586,
-				18721=>3077);
+				14869=>3586);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -4317,22 +4259,20 @@ citation     = <h1> Identification of Transcription Factor SEA2::GFP Binding Reg
  <b>Release Date:</b> 2011-05-06
 
 
-[Snyder_ANTIGFP_WIG_COMB_SKN1_GFP:70001]
+[Snyder_ANTIGFP_WIG_COMB_SKN1_GFP_L1:70001]
 glyph_subtype = density
 height       = 12
 
 
-[Snyder_ANTIGFP_WIG_COMB_SKN1_GFP]
-feature      = VISTA:5427
-	       VISTA:17913
-	       VISTA:18694
+[Snyder_ANTIGFP_WIG_COMB_SKN1_GFP_L1]
+feature      = VISTA:5427 
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 2622 2622 4631 3838
-track source = 5427 5423 17913 18694
+data source  = 2622 2622
+track source = 5427 5423
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -4366,17 +4306,11 @@ label        = sub {my $name = shift->name;
 label_position = left
 label density= 100
 smoothing_window = 16
-key          = SKN-1 Combined (GFP ChIP)
-select       = name;
-	       L1 "L1" = 2622;
-	       L4 "L4" = 4631;
-	       SKN-1_L3 "SKN-1_L3" = 3838;
+key          = SKN-1 Combined (GFP ChIP) 
 group_on     =
 link         = sub { my $feature = shift;
 		     my $src = $feature->source;
-		     my %subs = (5427=>2622,
-				 17913=>4631,
-				 18694=>3838);
+		     my %subs = (5427=>2622);
 		     if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -4441,10 +4375,8 @@ feature      = VISTA:8135
                VISTA:8304
                VISTA:8187
 	       VISTA:13503
-	       VISTA:18193
-	       VISTA:18299
-data source  = 3222 3222 3254 3254 3375 3375 3584 3584 4017 4018
-track source = 8135 8142 8304 8309 8187 8196 13503 13510 18193 18299
+data source  = 3222 3222 3254 3254 3375 3375 3584 3584
+track source = 8135 8142 8304 8309 8187 8196 13503 13510
 glyph        = vista_plot
 glyph select = vista_plot
 autoscale     = z_score
@@ -4468,8 +4400,6 @@ select       = name;
                UNC62_GFP_L3 "UNC-62_GFP_L3" = 3222;
                UNC62_GFP_L2 "UNC-62_GFP_L2" = 3254;
                UNC62_GFP_L1 "UNC-62_GFP_L1" = 3375;
-	       L4 "L4" = 4017;
-	       EMB "EMB" = 4018;
 category     = Transcription Factors: GFP ChIP
 sort_order   = name
 stranded     = 0
@@ -4876,14 +4806,13 @@ height       = 12
 
 [Snyder_ANTIGFP_WIG_AHA1_COMB]
 feature      = VISTA:15207
-	       VISTA:18777
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 3069 3069 2937
-track source = 15207 15214 18777
+data source  = 3069 3069
+track source = 15207 15214
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -4918,14 +4847,10 @@ label_position = left
 label density= 100
 smoothing_window = 16
 key          = AHA-1 Combined (GFP ChIP)
-select       = name;
-	       AHA-1 Combined (GFP ChIP) "AHA-1 Combined (GFP ChIP)" = 3069;
-	       AHA-1_L1 "AHA-1_L1" = 2937;
 group_on     =
 link         = sub { my $feature = shift;
                      my $src = $feature->source;
-                     my %subs = (15207=>3069,
-				 18777=>2937);
+                     my %subs = (15207=>3069);
                      if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -5475,14 +5400,13 @@ height       = 12
 [Snyder_ANTIGFP_WIG_LIN35_COMB]
 feature      = VISTA:15089
                VISTA:15116
-	       VISTA:18404
 glyph        = vista_plot
 glyph select = vista_plot
 graph_type   = boxes
 bump density = 250
 category     = Transcription Factors: GFP ChIP
-data source  = 3602 3602 3603 3603 3213
-track source = 15089 15101 15116 15126 18404
+data source  = 3602 3602 3603 3603
+track source = 15089 15101 15116 15126
 sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
 stranded     = 0
 height       = 30
@@ -5495,7 +5419,6 @@ database     = snyder
 select       = name;
                LIN-35_YL402_yAd "LIN-35_YL402_yAd" = 3602;
                LIN-35_YL398_L1 "LIN-35_YL398_L1" = 3603;
-	       YL409_L1 "YL409_L1" = 3213;
 min_peak     = 0
 box_subparts = 1
 sort_order   = name
@@ -5526,8 +5449,7 @@ group_on     =
 link         = sub { my $feature = shift;
                      my $src = $feature->source;
                      my %subs = (15089=>3602,
-                                 15116=>3603,
-				 18404=>3213);
+                                 15116=>3603);
                      if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -5812,64 +5734,59 @@ citation = <h1>
  <br />
  <b>Release Date:</b> 2012-09-13  Submission 3367
 
-[Snyder_ANTIGFP_WIG_JUN1_COMB:70001]
+[Snyder_ANTIGFP_WIG_SEM-4_COMB:70001]
 glyph_subtype = density
 height       = 12
 
-[Snyder_ANTIGFP_WIG_JUN1_COMB]
-feature      = VISTA:18079
-	       VISTA:18025
-	       VISTA:17861
-data source  = 18079 18025 17861
-track source = 4625 4629 4630
+
+[Snyder_ANTIGFP_WIG_SEM-4_COMB]
+feature      = VISTA:15149
+               VISTA:15155
 glyph        = vista_plot
 glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
 graph_type   = boxes
+bump density = 250
+category     = Transcription Factors: GFP ChIP
+data source  = 3606
+track source = 15149 15155
+sort_order   = sub ($$) {shift->feature->name cmp shift->feature->name}
+stranded     = 0
+height       = 30
+connector    = solid
+autoscale    = z_score
+variance_band= 1
+#min_score    = 0
+#max_score    = 200
 database     = snyder
 min_peak     = 0
 box_subparts = 1
 neg_color    = blue
-max_peak     = 0.01
+max_peak     = 0.002
 start_color  = blue
+balloon hover = sub {my $f = shift;
+                my $score = $f->score;
+                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
+                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".$score.")") : $f->name;}
 fgcolor      = black
 pos_color    = blue
 bgcolor      = orange
 alpha        = 80
 group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
+end_color    = lightblue
 bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = JUN-1 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L4 "L4" = 4625;
-	       L1 "L1" = 4629;
-	       L3 "L3" = 4630;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
+smoothing    = mean
 label        = sub {my $name = shift->name;
                     $name =~ s/_GFP//;
                     $name =~ s/_/ /g;
                     return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
 label_position = left
+label density= 100
+smoothing_window = 16
+key          = SEM-4 Combined (GFP ChIP)
+group_on     =
 link         = sub { my $feature = shift;
                      my $src = $feature->source;
-                     my %subs = (18079=>4625,
-				 18025=>4629,
-				 17861=>4630);
+		     my %subs= (15149=>3606);
                      if (!$subs{$src}) {
                       my $c     = $feature->seq_id;
                       my $name  = $feature->name;
@@ -5881,46 +5798,49 @@ link         = sub { my $feature = shift;
                       return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
                     }
                     return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
+citation = 
 citation = <h1>
-   Identification of Transcription Factor JUN-1::GFP Binding Regions in L4 
+   Identification of Transcription Factor SEM-4::GFP Binding Regions in L2 
    (Snyder project, Snyder subgroup)
  </h1>
- Synchronized L4 larvae from C. elegans strain OP234 (a transgenic strain engineered to express a gene fusion between jun-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
  <h2>Details</h2>
+ <p>Synchronized L2 larvae from C. elegans strain OP57 (a transgenic strain engineered to express a gene fusion between sem-4 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
  <h2>General Description</h2>
  <p>
  We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
  </p>
  <h2>Protocols</h2>
  <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
+     <li>
+       <b>Growth and isolation:</b>
+       <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>
+     </li>
+     <li>
+       <b>Sample preparation:</b>
+       <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>, <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>
+     </li>
+     <li>
+       <b>Data Analysis:</b>
+       <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>, <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>
+     </li>
+     <li>
+       <b>Other Protocols:</b>
+       <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>, <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>, <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>
+     </li>
  </ol>
  <h2>Experimental Reagents</h2>
  <ol>
- <b>Antibodies:</b>
+     <li>
+       <b>Antibodies:</b>
+       eGFP
+     </li>
  </ol>
  <h2> Sample Details </h2>
  <ol>
- <b>Animals/Lines:</b>
+     <li>
+       <b>Animals/Lines:</b>
+       Caenorhabditis elegans
+     </li>
  </ol>
  <br />
  <ul>
@@ -5928,3621 +5848,4 @@ citation = <h1>
     <ul>
  </ul>
  <br />
- <b>Release Date:</b> 2013-03-26  Submission 4625
-
-[Snyder_ANTIGFP_WIG_ZTF11_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_ZTF11_COMB]
-feature      = VISTA:18086
-	       VISTA:17976
-	       VISTA:18151
-data source  = 18086 17976 18151
-track source = 4626 4627 4791
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = ZTF-11 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L3 "L3" = 4626;
-	       L4 "L4" = 4627;
-	       EMB "EMB" = 4791;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18086=>4626,
-				 17967=>4627,
-				 18151=>4791);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_ZTF-11_GFP_L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP236 (a transgenic strain engineered to express a gene fusion between ztf-11 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-26  Submission 4627
-
-[Snyder_ANTIGFP_WIG_NHR76_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR76_COMB]
-feature      = VISTA:18012
-	       VISTA:18709
-data source  = 4628 2944
-track source = 18012 18709
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-76 Combined (GFP ChIP)
-select       = name;
-	       L4 "L4" = 4628;
-	       NHR-76_L3 "NHR-76_L3" = 2944;
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18012=>4628,
-				 18709=>2944);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_NHR-76_GFP_L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP203 (a transgenic strain engineered to express a gene fusion between nhr-76 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-26  Submission 4628
-
-[Snyder_ANTIGFP_WIG_ELT1_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_ELT1_COMB]
-feature      = VISTA:17947
-	       VISTA:18606
-data source  = 17947 18606
-track source = 4632 3843
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = ELT-1 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L2 "L2" = 4632;
-	       ELT-1_L3 "ELT-1_L3" = 3843;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (17947=>4632,
-				 18606=>3843);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_ELT-1_GFP_L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L2 larvae from C. elegans strain OP354 (a transgenic strain engineered to express a gene fusion between elt-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-26  Submission 4632
-
-[Snyder_ANTIGFP_WIG_NHR23_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR23_COMB]
-feature      = VISTA:18066
-	       VISTA:18671
-data source  = 4634 3837
-track source = 18066 18671
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-23 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18066=>4634,
-				 18671=>3837);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }i
-citation = <h1>
-   Snyder_NHR-23_GFP_L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L2 larvae from C. elegans strain OP43 (a transgenic strain engineered to express a gene fusion between nhr-23 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4634
-
-[Snyder_ANTIGFP_WIG_UNC39_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_UNC39_COMB]
-feature      = VISTA:18038
-	       VISTA:18004
-data source  = 18038 18004
-track source = 4635 4637
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = UNC-39 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       EMB "EMB" = 4635;
-	       L2 "L2" = 4637;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18038=>4635,
-				 18004=>4637);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_ELT-3_GFP_EMB 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized embryos from C. elegans strain OP75 (a transgenic strain engineered to express a gene fusion between elt-3 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4789
-
-[Snyder_ANTIGFP_WIG_NHR12_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR12_COMB]
-feature      = VISTA:17878
-	       VISTA:17927
-data source  = 17878 17927
-track source = 4790 4792
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-12 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L3 "L3" = 4790;
-	       EMB "EMB" = 4792;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (17878=>4790,
-				 17927=>4792);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_NHR-12_GFP_L3 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L3 larvae from C. elegans strain OP318 (a transgenic strain engineered to express a gene fusion between nhr-12 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4790
-
-[Snyder_ANTIGFP_WIG_LIN13_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_LIN13_COMB]
-feature      = VISTA:17881
-	       VISTA:17900
-data source  = 17881 17900
-track source = 4793 4794
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = LIN-13 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L1 "L1" = 4793;
-	       L2 "L2" = 4794;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (17881=>4793,
-				 17900=>4794);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_LIN-13_GFP_L1 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L1 larvae from C. elegans strain OP49 (a transgenic strain engineered to express a gene fusion between lin-13 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4793
-
-[Snyder_ANTIGFP_WIG_ZTF4_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_ZTF4_COMB]
-feature      = VISTA:18058
-	       VISTA:17992
-data source  = 18058 17992
-track source = 4796 4798
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = ZTF-4 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L2 "L2" = 4796;
-	       L1 "L1" = 4798;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18058=>4796,
-				 17992=>4798);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_ZTF-4_GFP_L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L2 larvae from C. elegans strain OP322 (a transgenic strain engineered to express a gene fusion between ztf-4 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4796
-
-[Snyder_ANTIGFP_WIG_NHR21_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR21_COMB]
-feature      = VISTA:18001
-data source  = 18001
-track source = 4797
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-21 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18001=>4797);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_NHR-21_GFP_L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L2 larvae from C. elegans strain OP361 (a transgenic strain engineered to express a gene fusion between nhr-21 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4797
-
-[Snyder_ANTIGFP_WIG_NHR10_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR10_COMB]
-feature      = VISTA:17868
-data source  = 17868
-track source = 4799
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-10 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (17868=>4799);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_NHR-10_GFP_L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP239 (a transgenic strain engineered to express a gene fusion between nhr-10 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4799
-
-[Snyder_ANTIGFP_WIG_CEH28_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_CEH28_COMB]
-feature      = VISTA:18049
-	       VISTA:18076
-data source  = 18049 18076
-track source = 4800 4801
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = CEH-28 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L4 "L4" = 4800;
-	       L3 "L3" = 4801;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18049=>4800,
-				 18076=>4801);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_CEH-28_GFP_L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP241 (a transgenic strain engineered to express a gene fusion between ceh-38 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4800
-
-[Snyder_ANTIGFP_WIG_LSY2_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_LSY2_COMB]
-feature      = VISTA:17909
-	       VISTA:17955
-	       VISTA:18613
-	       VISTA:18570
-data source  = 17909 17955 18613 18570
-track source = 4812 4813 3844 3845
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = LSY-2 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L2 v2 "L2 v2" = 4812;
-	       L4 v2 "L4 v2" = 4813;
-	       LSY-2_Emb "LSY-2_Emb" = 3844;
-	       LSY-2_L1 "LSY-2_L1" = 3845;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (17909=>4812,
-				 17955=>4813,
-				 18613=>3844,
-				 18570=>3845);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_LSY-2_GFP_L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L2 larvae from C. elegans strain OP240 (a transgenic strain engineered to express a gene fusion between lsy-2 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-27  Submission 4812
-
-[Snyder_ANTIGFP_WIG_ZIP2_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_ZIP2_COMB]
-feature      = VISTA:18116
-data source  = 18116
-track source = 4802
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = ZIP-2 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18116=>4802);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_ZIP-2_GFP_L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP432 (a transgenic strain engineered to express a gene fusion between zip-2 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-28  Submission 4802
-
-[Snyder_ANTIGFP_WIG_DVE1_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_DVE1_COMB]
-feature      = VISTA:18110
-	       VISTA:18227
-data source  = 18110 18227
-track source = 4803 4804
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = DVE-1 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L4 "L4" = 4803;
-	       LateEMB "LateEMB" = 4804;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18110=>4803,
-				 18227=>4804);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_DVE-1_GFP_L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP398 (a transgenic strain engineered to express a gene fusion between dve-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-28  Submission 4803
-
-
-[Snyder_ANTIGFP_WIG_HLH30_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_HLH30_COMB]
-feature      = VISTA:18176
-	       VISTA:18166
-data source  = 18176 18166
-track source = 4806 4807
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = HLH-30 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L4 "L4" = 4806;
-	       LateEMB "LateEMB" = 4807;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18176=>4806,
-				 18166=>4807);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_HLH-30_GFP_L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP433 (a transgenic strain engineered to express a gene fusion between hlh-30 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-28  Submission 4806
-
-[Snyder_ANTIGFP_WIG_MED1_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_MED1_COMB]
-feature      = VISTA:18137
-data source  = 18137
-track source = 4808
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = MED-1 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18137=>4808);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_MED-1_GFP_MIDEMB 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized embryos from C. elegans strain OP391 (a transgenic strain engineered to express a gene fusion between med-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-28  Submission 4808
-
-[Snyder_ANTIGFP_WIG_NFYA1_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NFYA1_COMB]
-feature      = VISTA:18144
-	       VISTA:18113
-	       VISTA:18161
-data source  = 18144 18113 18161
-track source = 4809 4810 4811
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NFYA-1 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L3 "L3" = 4809;
-	       LateEMB "LateEMB" = 4810;
-	       YA "YA" = 4811;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18144=>4809,
-				 18113=>4810,
-				 18161=>4811);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-tion = <h1>
-   Snyder_NFYA-1_GFP_L3 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L3 larvae from C. elegans strain OP404 (a transgenic strain engineered to express a gene fusion between nfya-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-03-28  Submission 4809
-
-[Snyder_ANTIGFP_WIG_FKH10_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_FKH10_COMB]
-feature      = VISTA:18332
-	       VISTA:18259
-data source  = 18332 18259
-track source = 4025 4028
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = FKH-10 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       LEMB "LEMB" = 4025;
-	       L4 "L4" = 4028;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18332=>4025,
-				 18259=>4028);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_FKH-10_GFP_LEMB 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized late embryos from C. elegans strain OP337 (a transgenic strain engineered to express a gene fusion between fkh-10 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-01  Submission 4025
-
-[Snyder_ANTIGFP_WIG_NHR67_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR67_COMB]
-feature      = VISTA:18308
-data source  = 18308
-track source = 4031
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-67 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18308=>4031);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Snyder_NHR-67_GFP_L3 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L3 larvae from C. elegans strain OP373 (a transgenic strain engineered to express a gene fusion between nhr-67 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-01  Submission 4031
-
-[Snyder_ANTIGFP_WIG_C34F69_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_C34F69_COMB]
-feature      = VISTA:18378
-data source  = 18378
-track source = 3208
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = C34F6.9 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18378=>3208);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor C34F6.9::GFP Binding Regions in L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized L2 larvae from C. elegans strain OP324 (a transgenic strain engineered to express a gene fusion between C34F6.9 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-04  Submission 3208
-
-[Snyder_ANTIGFP_WIG_SMA9_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_SMA9_COMB]
-feature      = VISTA:18478
-data source  = 18478
-track source = 3228
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = SMA-9 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18478=>3228);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor SMA-9::GFP Binding Regions in L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized L2 larvae from C. elegans strain OP130 (a transgenic strain engineered to express a gene fusion between sma-9 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-11  Submission 3228
-
-[Snyder_ANTIGFP_WIG_NHR25_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR25_COMB]
-feature      = VISTA:18540
-data source  = 18540
-track source = 3835
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-25 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18540=>3835);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor NHR-25::GFP Binding Regions in L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized L2 larvae from C. elegans strain OP33 (a transgenic strain engineered to express a gene fusion between nhr-25 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-12  Submission 3835
-
-[Snyder_ANTIGFP_WIG_NHR6_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR6_COMB]
-feature      = VISTA:18557
-data source  = 18557
-track source = 3836
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-6 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18557=>3836);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor NHR-6::GFP Binding Regions in L4 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L4 larvae from C. elegans strain OP90 (a transgenic strain engineered to express a gene fusion between nhr-6 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-15  Submission 3836
-
-[Snyder_ANTIGFP_WIG_F23F129_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_F23F129_COMB]
-feature      = VISTA:18605
-data source  = 18605
-track source = 3839
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = F23F12.9 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18605=>3839);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor F23F12.9::GFP Binding Regions in Embryos 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized embryos from C. elegans strain OP327 (a transgenic strain engineered to express a gene fusion between F23F12.9 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-15  Submission 3839
-
-[Snyder_ANTIGFP_WIG_NHR237_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR237_COMB]
-feature      = VISTA:18392
-	       VISTA:18638
-	       VISTA:18681
-data source  = 18392 18638 18681
-track source = 3850 3853 3852
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-237 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       L3 "L3" = 3850;
-	       NHR-237_EMB "NHR-237_EMB" = 3853;
-	       NHR-237_L1 "NHR-237_L1" = 3852;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18392=>3850,
-				 18638=>3853,
-				 18681=>3852);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor NHR-237::GFP Binding Regions in EMB 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized embyros from C. elegans strain OP228 (a transgenic strain engineered to express a gene fusion between nhr-237 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-16  Submission 3853
-
-[Snyder_ANTIGFP_WIG_PAX1_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_PAX1_COMB]
-feature      = VISTA:18433
-data source  = 18433
-track source = 3856
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = PAX-1 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18433=>3856);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor PAX-1::GFP Binding Regions in EMB 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized embryos from C. elegans strain OP117 (a transgenic strain engineered to express a gene fusion between pax-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-09  Submission 3856
-
-
-[Snyder_ANTIGFP_WIG_NHR2_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_NHR2_COMB]
-feature      = VISTA:18584
-data source  = 18584
-track source = 3859
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = NHR-2 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18584=>3859);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor NHR-2::GFP Binding Regions in EMB 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized embryos from C. elegans strain OP99 (a transgenic strain engineered to express a gene fusion between nhr-2 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-15  Submission 3859
-
-[Snyder_ANTIGFP_WIG_FKH2_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_FKH2_COMB]
-feature      = VISTA:18767
-data source  = 18767
-track source = 2942
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = FKH-2 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18767=>2942);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor FKH-2::GFP Binding Regions in L3 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized L3 larvae from C. elegans strain OP185 (a transgenic strain engineered to express a gene fusion between fkh-2 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-18  Submission 2942
-
-[Snyder_ANTIGFP_WIG_MML1_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_MML1_COMB]
-feature      = VISTA:18740
-data source  = 18740
-track source = 2943
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = MML-1 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18740=>2943);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor MML-1::GFP Binding Regions in L3 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized L3 larvae from C. elegans strain OP198 (a transgenic strain engineered to express a gene fusion between mml-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-18  Submission 2943
-
-[Snyder_ANTIGFP_WIG_HAM1_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_HAM1_COMB]
-feature      = VISTA:18799
-	       VISTA:18643
-data source  = 18799 18643
-track source = 3152 3842
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = HAM-1 Combined (GFP ChIP)
-sort_order   = name
-select       = name;
-	       HAM-1_L1 "HAM-1_L1" = 3152;
-	       HAM-1_L4 "HAM-1_L4" = 3842;
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18799=>3152,
-				 18643=>3842);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor HAM-1::GFP Binding Regions in L1 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized fed L1 larvae from C. elegans strain OP102 (a transgenic strain engineered to express a gene fusion between ham-1 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-19  Submission 3152
-
-[Snyder_ANTIGFP_WIG_CEH16_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_CEH16_COMB]
-feature      = VISTA:18793
-data source  = 18793
-track source = 3209
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = CEH-16 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18793=>3209);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor CEH-16::GFP Binding Regions in L2 
-   (Snyder project, Snyder subgroup)
- </h1>
- <h2>Details</h2>
- <p>Synchronized L2 larvae from C. elegans strain OP82 (a transgenic strain engineered to express a gene fusion between ceh-16 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.</p>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-19  Submission 3209
-
-[Snyder_ANTIGFP_WIG_CEH39_COMB:70001]
-glyph_subtype = density
-height       = 12
-
-[Snyder_ANTIGFP_WIG_CEH39_COMB]
-feature      = VISTA:18665
-data source  = 3858
-track source = 18665
-glyph        = vista_plot
-glyph select = vista_plot
-autoscale    = z_score
-variance_band = 1
-graph_type   = boxes
-database     = snyder
-min_peak     = 0
-box_subparts = 1
-neg_color    = blue
-max_peak     = 0.01
-start_color  = blue
-fgcolor      = black
-pos_color    = blue
-bgcolor      = orange
-alpha        = 80
-group_label  = 0
-end_color  = lightblue
-bump density = 250
-stranded     = 0
-height       = 30
-connector    = solid
-label density= 100
-smoothing    = mean
-smoothing_window = 10
-group_on     =
-bicolor_pivot= zero
-category     = Transcription Factors: GFP ChIP
-key          = CEH-39 Combined (GFP ChIP)
-sort_order   = name
-
-balloon hover = sub {my $f = shift;
-                my $score = $f->score;
-                my $img_url = "/cgi-bin/gb2/gbrowse_key_img?min=0;max=0.002;start_c=blue;end_c=lightblue";
-                return $score ? join (" ","<img width=215 height=88 src=\"/images/vista_legend.png\"/><br/><img width=120 height=23 src=\"".$img_url."\"/>",$f->name,"(q-value:".sprintf("%.5e", $score).")") : $f->name;}
-label        = sub {my $name = shift->name;
-                    $name =~ s/_GFP//;
-                    $name =~ s/_/ /g;
-                    return $name =~ /(.+?) (.+)/ ? sprintf("%-6s %-5s",$1,$2) : sprintf("%-18s",$name); }
-label_position = left
-link         = sub { my $feature = shift;
-                     my $src = $feature->source;
-                     my %subs = (18665=>3858);
-                     if (!$subs{$src}) {
-                      my $c     = $feature->seq_id;
-                      my $name  = $feature->name;
-                      my $class = eval {CGI::escape($feature->class)}||'';
-                      my $ref   = CGI::escape("$c");
-                      my $start = CGI::escape($feature->start);
-                      my $end   = CGI::escape($feature->end);
-                      my $id    = eval {CGI::escape($feature->primary_id)};
-                      return "../../gbrowse_details/worm?name=$name;class=$class;ref=$ref;start=$start;end=$end;feature_id=$id;db_id=snyder:database";
-                    }
-                    return "http://intermine.modencode.org/query/portal.do?externalid=modENCODE_$subs{$src}&class=Submission"; }
-citation = <h1>
-   Identification of Transcription Factor CEH-39::GFP Binding Regions in EMB 
-   (Snyder project, Snyder subgroup)
- </h1>
- Synchronized embyros from C. elegans strain OP169 (a transgenic strain engineered to express a gene fusion between ceh-39 and GFP) were treated with the cross-linking reagent formaldehyde. After lysis and sonication, the chromatin was immunoprecipitated with an affinity-purified antibody that recognizes GFP. The bound DNA was purified and sequenced in an Illumina GA-2. A sample of the input DNA was sequenced in parallel. The ChIP-seq data generated by this experiment was analyzed using the PeakSeq peak-calling algorithm to predict protein binding sites in the C. elegans genome.
- <br/><br/>
- <h2>Details</h2>
- <h2>General Description</h2>
- <p>
- We are identifying the DNA binding sites for 300 transcription factors in C. elegans. Each transcription factor gene is tagged with the same GFP fusion protein, permitting validation of the gene's correct spatio-temporal expression pattern in transgenic animals.  Chromatin immunoprecipitation on each strain is peformed using an anti-GFP antibody, and any bound DNA is deep-sequenced using Solexa GA2 technology. 
- </p>
- <h2>Protocols</h2>
- <ol>
- <li>
- <b>Growth and isolation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Plated_Worm_Growth_and_Harvest:MS:1&oldid=27005">Plated Worm Growth and Harvest</a>     
- </li>
- <li>
- <b>Sample preparation:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP:MS:1&oldid=23202">ChIP</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=DNA_Sequencing_Illumina:MS:1&oldid=32503">Illumina Deep Sequencing</a>     
- </li>
- <li>
- <b>Data Analysis:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Merging:MS:1&oldid=23034">Illumina Data Merging</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Skip_Illumina_Data_Merging:MS:1&oldid=25729">Skip Illumina Data Merging</a>     
- </li>
- <li>
- <b>Other Protocols:</b>
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-Seq_Peak-calling:MS:1&oldid=30100">Peak Calling</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=Illumina_Data_Analysis:MS:1&oldid=33949">Illumina Data Analysis</a>,
-  <a href="http://wiki.modencode.org/project/index.php?title=ChIP-seq_replicate_verification:MS:1&oldid=33875">ChIP-seq replicate verification</a>
- </li>
- </ol>
- <h2>Experimental Reagents</h2>
- <ol>
- <b>Antibodies:</b>
- </ol>
- <h2> Sample Details </h2>
- <ol>
- <b>Animals/Lines:</b>
- </ol>
- <br />
- <ul>
-  </ul>
-    <ul>
- </ul>
- <br />
- <b>Release Date:</b> 2013-04-16  Submission 3858
+ <b>Release Date:</b> 2012-10-10 


### PR DESCRIPTION
The latest commit appears to be quite out of date
compared to the configuration currently in production.
There are several other changes in snyder_gfp_tf.conf,
not related to modENCODE_3605 & 3606. They have been
included in this commit.
